### PR TITLE
Fixed lfcgi.isfcgi(), added lfcgi.finish()

### DIFF
--- a/src/fastcgi/lfcgi.c
+++ b/src/fastcgi/lfcgi.c
@@ -520,6 +520,16 @@ static int lfcgi_accept (lua_State *L) {
 	return 1;
 }
 
+/*
+* Do not use anything from the lfcgi module except accept()
+* after you called this function. Including io.* stuff
+* if you replaced originals.
+*/
+static int lfcgi_finish (lua_State *L) {
+	FCGI_Finish();
+	return 0;
+}
+
 static int lfcgi_getenv (lua_State *L) {
 	const char* envVar = luaL_checkstring(L, 1);
 	char* val = getenv(envVar);
@@ -582,6 +592,7 @@ static const luaL_reg iolib[] = {
   {"type", io_type},
   {"write", io_write},
   {"accept", lfcgi_accept},
+  {"finish", lfcgi_finish},
   {"getenv", lfcgi_getenv},
   {"getpid", lfcgi_getpid},
   {"environ", lfcgi_environ},


### PR DESCRIPTION
I need lfcgi.finish() to be able to do select() on fcgi input socket — so lfcgi.accept() would not block my WSAPI application.

And lfcgi.isfcgi() plainly does not work for my application. I used function from official API instead.
