### PR TITLE
wsapi.request.qs_encode yields invalid querystrings

### DIFF
--- a/src/wsapi/request.lua
+++ b/src/wsapi/request.lua
@@ -168,7 +168,8 @@ function methods:route_link(route, query, ...)
   local builder = self.mk_app["link_" .. route]
   if builder then
     local uri = builder(self.mk_app, self.env, ...)
-    return uri .. self:qs_encode(query)
+    local qs = self:qs_encode(query)
+    return uri .. (qs ~= "" and ("?"..qs) or "")
   else
     error("there is no route named " .. route)
   end
@@ -177,11 +178,13 @@ end
 function methods:link(url, query)
   local prefix = (self.mk_app and self.mk_app.prefix) or self.script_name
   local uri = prefix .. url
-  return prefix .. url .. self:qs_encode(query)
+  local qs = self:qs_encode(query)
+  return prefix .. url .. (qs ~= "" and ("?"..qs) or "")
 end
 
 function methods:absolute_link(url, query)
-  return url .. self:qs_encode(query)
+  local qs = self:qs_encode(query)
+  return url .. (qs ~= "" and ("?"..qs) or "")
 end
 
 function methods:static_link(url)

--- a/tests/mock_test.lua
+++ b/tests/mock_test.lua
@@ -15,7 +15,7 @@ do
   local response, request = app:get("/", {hello = "world"})
   assert(response.code                    == 200)
   assert(request.request_method           == "GET")
-  assert(request.query_string             == "?hello=world")
+  assert(request.query_string             == "hello=world")
   assert(response.headers["Content-type"] == "text/html")
   assert(response.body                    == "hello world!")
 end


### PR DESCRIPTION
According to [RFC 3875](http://www.ietf.org/rfc/rfc3875), the question mark is not part of the querystring.

This code fails because the first key-value pair is missing:

``` lua
local mock = require "wsapi.mock"
local ws_request = require "wsapi.request"

local test_app = function(wsapi_env)
    local qs = wsapi_env.QUERY_STRING
    print("QUERY_STRING: " .. qs)

    local req = ws_request.new(wsapi_env)

    return 200, {}, coroutine.wrap(function()
        coroutine.yield(tostring(req.params.key1) .. tostring(req.params.key2))
    end)
end

local app = mock.make_handler(test_app)

local response, request = app:get("test", { key1="1", key2="2"})
assert(response.code == 200)
assert(response.body == "12")
```

I could fix that in _wsapi.mock_, just stripping the question mark, but it seems wrong to me.
If _wsapi.request.qs_encode_ does not include it, methods like _request.route_link_ and _request.link_ should be fixed. That seems like the proper thing to do.
What do you think?
