### PR TITLE
Mock requests return wrong data when reading

### DIFF
--- a/src/wsapi/mock.lua
+++ b/src/wsapi/mock.lua
@@ -71,7 +71,7 @@ local function make_io_object(content)
   function receiver:read(len)
     len = len or (#self.buffer - self.bytes_read)
     if self.bytes_read >= #self.buffer then return nil end
-    local s = self.buffer:sub(self.bytes_read + 1, len)
+    local s = self.buffer:sub(self.bytes_read + 1, self.bytes_read + len)
     self.bytes_read = self.bytes_read + len
     if self.bytes_read > #self.buffer then self.bytes_read = #self.buffer end
     return s


### PR DESCRIPTION
Reading data in chunk from the request yields the wrong data:

``` lua
local mock = require "wsapi.mock"
local ws_request = require "wsapi.request"

local test_app = function(wsapi_env)

    return 200, {}, coroutine.wrap(function()
        coroutine.yield(wsapi_env.input:read(2048))
        coroutine.yield(wsapi_env.input:read(2048))
    end)
end

local app = mock.make_handler(test_app)

local data = ("AB"):rep(1024) .. ("CD"):rep(1024)
local response, request = app:post("test", data, { ["Content-Length"] = #data, ["Content-Type"] = "text/plain" })

assert(response.body == data)
```

The problem is here:
https://github.com/keplerproject/wsapi/blob/master/src/wsapi/mock.lua#L74

It should be:

``` lua
local s = self.buffer:sub(self.bytes_read + 1, self.bytes_read + len)
```
