### PR TITLE
Use specified Content-Length if provided

### DIFF
--- a/src/wsapi/mock.lua
+++ b/src/wsapi/mock.lua
@@ -124,7 +124,7 @@ local function build_post(path, params, headers)
     req.QUERY_STRING = qs
   end
 
-  req.CONTENT_LENGTH = #body
+  req.CONTENT_LENGTH = headers["Content-Length"] or #body
 
   return {
     env    = req,


### PR DESCRIPTION
This change allows to test how endpoints deal with invalid POST (advertising more or less bytes than actually sent, etc).
