### PR TITLE
make status returning more consistent

### DIFF
--- a/src/wsapi/common.lua
+++ b/src/wsapi/common.lua
@@ -237,7 +237,7 @@ function _M.send_error(out, err, msg, out_method, err_method, http_response)
    local write_err = err[err_method or "write"]
    write_err(err, "WSAPI error in application: " .. tostring(msg) .. "\n")
    local msg = _M.error_html(msg)
-   local status, headers, res_iter = "500 Internal Server Error", {
+   local status, headers, res_iter = 500, {
         ["Content-Type"] = "text/html",
         ["Content-Length"] = #msg
       }, make_iterator(msg)
@@ -250,7 +250,7 @@ end
 function _M.send_404(out, msg, out_method, http_response)
    local write = out[out_method or "write"]
    local msg = _M.status_404_html(msg)
-   local status, headers, res_iter = "404 Not Found", {
+   local status, headers, res_iter = 404, {
         ["Content-Type"] = "text/html",
         ["Content-Length"] = #msg
       }, make_iterator(msg)


### PR DESCRIPTION
Functions `_M.send_404()` and `_M.send_500()` are returning `status` which is meant to be HTTP Status Code. In turn `_M.run()` returning result of `_M.send_404()` or `_M.send_500()` which also has meaning of HTTP Status Code. In common loops like [cgi.lua](https://github.com/keplerproject/wsapi/blob/master/src/wsapi/cgi.lua) and [fastcgi.lua](https://github.com/keplerproject/wsapi/blob/master/src/wsapi/fastcgi.lua) these returnings are not used, but if they would consistency would be violated.
