### PR TITLE
Prepares 1.6.1 release

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ tries to follow standard Lua idioms.
 WSAPI is free software and uses the same license as Lua 5.1
 
 Status
-Current version is 1.6. It supports both Lua 5.1 and Lua 5.2.
+Current version is 1.6.1. It supports both Lua 5.1 and Lua 5.2.
 
 Download
 WSAPI can be downloaded from its LuaForge page. You can also get WSAPI using
@@ -31,6 +31,13 @@ Latest Sources and Bug Tracker
 WSAPI CVS and bug tracker are available at its Github page.
 
 History
+
+WSAPI 1.6.1 [21/Mar/2014]
+    * Restores Lua 5.1 compatibility (incorrect usage of coxpcall)
+    * Improvements to wsapi.mock
+    * wsapi.request.qs_encode produces proper querystrings
+    * FastCGI fixes
+    * Additional options for cookies such as httponly and max age.
 
 WSAPI 1.6 [30/Jan/2013]
     * Lua 5.2 compatibility
@@ -82,7 +89,7 @@ WSAPI 1.3 [18/Mar/2010]
     * Added an `extra_vars` paremeter to wsapi.xavante.makeHandler and wsapi.xavante.makeGenericHandler, to
       let you pass extra variables in the WSAPI environment
     * Added `overwrite` option to wsapi.request that tells the parameter parser to overwrite repeated parameters
-      instead of collecting them in a list    
+      instead of collecting them in a list
     * Added a parameter `isolated` to the persistent generic loaders that controls whether you isolate
       each script in a Lua state or not
     * Added parameters to the persistent generic loaders that let the user control the life cycle of Lua
@@ -97,7 +104,7 @@ WSAPI 1.2 [27/Oct/2009]
     * Adds "wsapi" laucher script, to start a Xavante WSAPI server
     * Fixed "undefined media type" error
     * Added is_empty utility function to check if a string is nil or ''
-    * Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses 
+    * Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses
     * Changing order of evaluating PATH_TRANSLATED and SCRIPT_FILENAME, to make non-wrapped launchers work in OSX Apache
     * Reload support for load_isolated_launcher
 

--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -3,9 +3,9 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<title>WSAPI</title>
+        <title>WSAPI</title>
     <link rel="stylesheet" href="doc.css" type="text/css"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 
 <body>
@@ -14,30 +14,30 @@
 
 <div id="product">
 
-	<div id="product_logo">
+        <div id="product_logo">
         <a href="http://wsapi.luaforge.net">
-		<img alt="WSAPI" src="wsapi.png"/>
-	    </a>
+                <img alt="WSAPI" src="wsapi.png"/>
+            </a>
     </div>
-	<div id="product_name"><big><strong>WSAPI</strong></big></div>
-	<div id="product_description">Lua Web Server API</div>
+        <div id="product_name"><big><strong>WSAPI</strong></big></div>
+        <div id="product_description">Lua Web Server API</div>
 </div> <!-- id="product" -->
 
 <div id="main">
-	
+
 <div id="navigation">
 <h1>WSAPI</h1>
-	<ul>
+        <ul>
 
-		<li><strong>Home</strong></li>
+                <li><strong>Home</strong></li>
 
-		<li><a href="manual.html">Manual</a></li>
+                <li><a href="manual.html">Manual</a></li>
 
-		<li><a href="libraries.html">Libraries</a></li>
+                <li><a href="libraries.html">Libraries</a></li>
 
-		<li><a href="license.html">License</a></li>
+                <li><a href="license.html">License</a></li>
 
-	</ul>
+        </ul>
 </div> <!-- id="navigation" -->
 
 <div id="content">
@@ -62,7 +62,7 @@ clone of either of them, though, and tries to follow standard Lua idioms.</p>
 
 <h2>Status</h2>
 
-<p>Current version is 1.5. It was developed for Lua 5.1.</p>
+<p>Current version is 1.6.1. It supports both Lua 5.1 and Lua 5.2.</p>
 
 <h2>Download</h2>
 
@@ -76,60 +76,76 @@ luarocks install wsapi-xavante
 
 <h3>Unix Installer Script</h3>
 
-<p>You can also get an installer script that installs Lua+LuaRocks+WSAPI 
-<a href="http://github.com/downloads/keplerproject/wsapi/wsapi-install-1.5.tar.gz">here</a>. See
+<p>You can also get an installer script that installs Lua+LuaRocks+WSAPI
+<a href="http://www.keplerproject.org/files/wsapi-install-1.6.1.tar.gz">here</a>. See
 the <a href="manual.html">manual</a> for installation instructions.</p>
 
 <h3>Customizing the installer</h3>
 
-<p>There is a section of wsapi-install-1.5 with the parameters that 
-control the installer: </p>
+<p>There is a section of wsapi-install-1.6 with the parameters that
+control the installer:</p>
 
 
 <pre class="example">
-# Installer parameters 
+# Installer parameters
 
-LUA_VERSION=5.1.4 
-PACKAGE=WSAPI 
-PACKAGE_OPT=wsapi 
-PACKAGE_ROCK=wsapi-xavante 
-INSTALLER_VERSION=0.6 
-PACKAGE_VERSION=1.5
+LUA_VERSION=5.2.1
+PACKAGE=WSAPI
+PACKAGE_OPT=wsapi
+PACKAGE_ROCK=wsapi-xavante
+INSTALLER_VERSION=0.7
+PACKAGE_VERSION=1.6
 LUAROCKS_REPO=http://luarocks.org/repositories/rocks
-LUAROCKS_URL=http://www.luarocks.org/releases/luarocks-2.0.4.1.tar.gz
-LUAROCKS_VERSION=2.0.4.1 
+LUAROCKS_URL=http://www.luarocks.org/releases/luarocks-2.0.12.tar.gz
+LUAROCKS_VERSION=2.0.12
 </pre>
 
 
-<p>To install something else change PACKAGE to the full name of the 
-package, PACKAGE_OPT to the name of the --with-foo option that lets 
-the user override the version (or skip installation of the package), 
-PACKAGE_ROCK to the name of the rock, and PACKAGE_VERSION to the 
-version. Also change LUAROCKS_REPO if you want to use another 
-repository (the installer uses --from, so will pull packages from 
-other repositories if the one you specified does not have them). </p>
+<p>To install something else change PACKAGE to the full name of the
+package, PACKAGE_OPT to the name of the --with-foo option that lets
+the user override the version (or skip installation of the package),
+PACKAGE_ROCK to the name of the rock, and PACKAGE_VERSION to the
+version. Also change LUAROCKS_REPO if you want to use another
+repository (the installer uses --from, so will pull packages from
+other repositories if the one you specified does not have them).</p>
 
-<p>If there is a LuaRocks update then change LUAROCKS_URL and 
-LUAROCKS_VERSION. Changing Lua version is much more involved, so I 
-won't go into that. </p>
+<p>If there is a LuaRocks update then change LUAROCKS_URL and
+LUAROCKS_VERSION. Changing Lua version is much more involved, so I
+won't go into that.</p>
 
-<p>Now to make the tarball, put the installer script in an empty folder and run: </p>
+<p>Now to make the tarball, put the installer script in an empty folder and run:</p>
 
 
 <pre class = "example">
-bash ./your-install-script --prefix=/tmp/anything --bootstrap 
+bash ./your-install-script --prefix=/tmp/anything --bootstrap
 </pre>
 
 
-<p>After it finishes you will have lua-5.1.4.tar.gz, 
-luarocks-2.0.4.1.tar.gz, and a rocks folder with .src.rocks for all the 
-rocks that the installer installs. </p>
+<p>After it finishes you will have lua-5.2.1.tar.gz,
+luarocks-2.0.12.tar.gz, and a rocks folder with .src.rocks for all the
+rocks that the installer installs.</p>
 
 <h2>Latest Sources and Bug Tracker</h2>
 
 <p>WSAPI sources and bug tracker are available at its <a href="http://github.com/keplerproject/wsapi/">Github</a> page.</p>
 
 <h2>History</h2>
+
+<p><strong>WSAPI 1.6.1</strong> [21/Mar/2014]</p>
+
+<ul>
+    <li>Restores Lua 5.1 compatibility (incorrect usage of coxpcall)</li>
+    <li>Improvements to wsapi.mock</li>
+    <li>wsapi.request.qs_encode produces proper querystrings</li>
+    <li>FastCGI fixes</li>
+    <li>Additional options for cookies such as httponly and max age.</li>
+</ul>
+
+<p><strong>WSAPI 1.6</strong> [30/Jan/2013]</p>
+
+<ul>
+    <li>Lua 5.2 compatibility</li>
+</ul>
 
 <p><strong>WSAPI 1.5</strong> [21/Apr/2011]</p>
 
@@ -198,7 +214,7 @@ rocks that the installer installs. </p>
     <li>Added an <code>extra_vars</code> paremeter to wsapi.xavante.makeHandler and wsapi.xavante.makeGenericHandler, to
     let you pass extra variables in the WSAPI environment</li>
     <li>Added <code>overwrite</code> option to wsapi.request that tells the parameter parser to overwrite repeated parameters
-    instead of collecting them in a list    </li>
+    instead of collecting them in a list</li>
     <li>Added a parameter <code>isolated</code> to the persistent generic loaders that controls whether you isolate
     each script in a Lua state or not</li>
     <li>Added parameters to the persistent generic loaders that let the user control the life cycle of Lua
@@ -216,7 +232,7 @@ rocks that the installer installs. </p>
     <li>Adds "wsapi" laucher script, to start a Xavante WSAPI server</li>
     <li>Fixed "undefined media type" error</li>
     <li>Added is_empty utility function to check if a string is nil or ''</li>
-    <li>Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses </li>
+    <li>Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses</li>
     <li>Changing order of evaluating PATH_TRANSLATED and SCRIPT_FILENAME, to make non-wrapped launchers work in OSX Apache</li>
     <li>Reload support for load_isolated_launcher</li>
 </ul>
@@ -250,8 +266,8 @@ Andr&eacute; Carregal, and is maintained by Fabio Mascarenhas.</p>
 <p>For more information please <a href="mailto:info-NO-SPAM-THANKS@keplerproject.org">contact us</a>.
 Comments are welcome!</p>
 
-<p>You can also reach us and other developers and users on the Kepler Project 
-<a href="http://luaforge.net/mail/?group_id=104">mailing list</a>. </p>
+<p>You can also reach us and other developers and users on the Kepler Project
+<a href="http://luaforge.net/mail/?group_id=104">mailing list</a>.</p>
 
 
 
@@ -261,7 +277,7 @@ Comments are welcome!</p>
 </div> <!-- id="main" -->
 
 <div id="about">
-	<p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
+        <p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
 </div> <!-- id="about" -->
 
 </div> <!-- id="container" -->

--- a/doc/us/index.md
+++ b/doc/us/index.md
@@ -17,7 +17,7 @@ WSAPI is free software and uses the same license as Lua 5.1.
 
 ## Status
 
-Current version is 1.6. It supports both Lua 5.1 and Lua 5.2.
+Current version is 1.6.1. It supports both Lua 5.1 and Lua 5.2.
 
 ## Download
 
@@ -29,56 +29,64 @@ luarocks install wsapi-xavante
 
 ### Unix Installer Script
 
-You can also get an installer script that installs Lua+LuaRocks+WSAPI 
-[here](http://www.keplerproject.org/files/wsapi-install-1.6.tar.gz). See
+You can also get an installer script that installs Lua+LuaRocks+WSAPI
+[here](http://www.keplerproject.org/files/wsapi-install-1.6.1.tar.gz). See
 the [manual](manual.html) for installation instructions.
 
 ### Customizing the installer
 
-There is a section of wsapi-install-1.6 with the parameters that 
-control the installer: 
+There is a section of wsapi-install-1.6 with the parameters that
+control the installer:
 
 <pre class="example">
-# Installer parameters 
+# Installer parameters
 
-LUA_VERSION=5.2.1 
-PACKAGE=WSAPI 
-PACKAGE_OPT=wsapi 
-PACKAGE_ROCK=wsapi-xavante 
-INSTALLER_VERSION=0.7 
+LUA_VERSION=5.2.1
+PACKAGE=WSAPI
+PACKAGE_OPT=wsapi
+PACKAGE_ROCK=wsapi-xavante
+INSTALLER_VERSION=0.7
 PACKAGE_VERSION=1.6
 LUAROCKS_REPO=http://luarocks.org/repositories/rocks
 LUAROCKS_URL=http://www.luarocks.org/releases/luarocks-2.0.12.tar.gz
-LUAROCKS_VERSION=2.0.12 
+LUAROCKS_VERSION=2.0.12
 </pre>
 
-To install something else change PACKAGE to the full name of the 
-package, PACKAGE\_OPT to the name of the --with-foo option that lets 
-the user override the version (or skip installation of the package), 
-PACKAGE\_ROCK to the name of the rock, and PACKAGE\_VERSION to the 
-version. Also change LUAROCKS\_REPO if you want to use another 
-repository (the installer uses --from, so will pull packages from 
-other repositories if the one you specified does not have them). 
+To install something else change PACKAGE to the full name of the
+package, PACKAGE\_OPT to the name of the --with-foo option that lets
+the user override the version (or skip installation of the package),
+PACKAGE\_ROCK to the name of the rock, and PACKAGE\_VERSION to the
+version. Also change LUAROCKS\_REPO if you want to use another
+repository (the installer uses --from, so will pull packages from
+other repositories if the one you specified does not have them).
 
-If there is a LuaRocks update then change LUAROCKS\_URL and 
-LUAROCKS\_VERSION. Changing Lua version is much more involved, so I 
-won't go into that. 
+If there is a LuaRocks update then change LUAROCKS\_URL and
+LUAROCKS\_VERSION. Changing Lua version is much more involved, so I
+won't go into that.
 
-Now to make the tarball, put the installer script in an empty folder and run: 
+Now to make the tarball, put the installer script in an empty folder and run:
 
 <pre class = "example">
-bash ./your-install-script --prefix=/tmp/anything --bootstrap 
+bash ./your-install-script --prefix=/tmp/anything --bootstrap
 </pre>
 
-After it finishes you will have lua-5.2.1.tar.gz, 
-luarocks-2.0.12.tar.gz, and a rocks folder with .src.rocks for all the 
-rocks that the installer installs. 
+After it finishes you will have lua-5.2.1.tar.gz,
+luarocks-2.0.12.tar.gz, and a rocks folder with .src.rocks for all the
+rocks that the installer installs.
 
 ## Latest Sources and Bug Tracker
 
 WSAPI sources and bug tracker are available at its [Github](http://github.com/keplerproject/wsapi/) page.
 
 ## History
+
+**WSAPI 1.6.1** [21/Mar/2014]
+
+* Restores Lua 5.1 compatibility (incorrect usage of coxpcall)
+* Improvements to wsapi.mock
+* wsapi.request.qs_encode produces proper querystrings
+* FastCGI fixes
+* Additional options for cookies such as httponly and max age.
 
 **WSAPI 1.6** [30/Jan/2013]
 
@@ -138,7 +146,7 @@ WSAPI sources and bug tracker are available at its [Github](http://github.com/ke
 * Added an `extra_vars` paremeter to wsapi.xavante.makeHandler and wsapi.xavante.makeGenericHandler, to
   let you pass extra variables in the WSAPI environment
 * Added `overwrite` option to wsapi.request that tells the parameter parser to overwrite repeated parameters
-  instead of collecting them in a list    
+  instead of collecting them in a list
 * Added a parameter `isolated` to the persistent generic loaders that controls whether you isolate
   each script in a Lua state or not
 * Added parameters to the persistent generic loaders that let the user control the life cycle of Lua
@@ -154,7 +162,7 @@ WSAPI sources and bug tracker are available at its [Github](http://github.com/ke
 * Adds "wsapi" laucher script, to start a Xavante WSAPI server
 * Fixed "undefined media type" error
 * Added is_empty utility function to check if a string is nil or ''
-* Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses 
+* Fixed bug with empty bodies in wsapi.xavante, and added full http status codes to responses
 * Changing order of evaluating PATH\_TRANSLATED and SCRIPT\_FILENAME, to make non-wrapped launchers work in OSX Apache
 * Reload support for load\_isolated\_launcher
 
@@ -183,6 +191,6 @@ Andr&eacute; Carregal, and is maintained by Fabio Mascarenhas.
 For more information please [contact us](mailto:info-NO-SPAM-THANKS@keplerproject.org).
 Comments are welcome!
 
-You can also reach us and other developers and users on the Kepler Project 
-[mailing list](http://luaforge.net/mail/?group_id=104). 
+You can also reach us and other developers and users on the Kepler Project
+[mailing list](http://luaforge.net/mail/?group_id=104).
 

--- a/doc/us/libraries.html
+++ b/doc/us/libraries.html
@@ -3,9 +3,9 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<title>WSAPI</title>
+        <title>WSAPI</title>
     <link rel="stylesheet" href="doc.css" type="text/css"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 
 <body>
@@ -14,30 +14,30 @@
 
 <div id="product">
 
-	<div id="product_logo">
+        <div id="product_logo">
         <a href="http://wsapi.luaforge.net">
-		<img alt="WSAPI" src="wsapi.png"/>
-	    </a>
+                <img alt="WSAPI" src="wsapi.png"/>
+            </a>
     </div>
-	<div id="product_name"><big><strong>WSAPI</strong></big></div>
-	<div id="product_description">Lua Web Server API</div>
+        <div id="product_name"><big><strong>WSAPI</strong></big></div>
+        <div id="product_description">Lua Web Server API</div>
 </div> <!-- id="product" -->
 
 <div id="main">
-	
+
 <div id="navigation">
 <h1>WSAPI</h1>
-	<ul>
+        <ul>
 
-		<li><a href="index.html">Home</a></li>
+                <li><a href="index.html">Home</a></li>
 
-		<li><a href="manual.html">Manual</a></li>
+                <li><a href="manual.html">Manual</a></li>
 
-		<li><strong>Libraries</strong></li>
+                <li><strong>Libraries</strong></li>
 
-		<li><a href="license.html">License</a></li>
+                <li><a href="license.html">License</a></li>
 
-	</ul>
+        </ul>
 </div> <!-- id="navigation" -->
 
 <div id="content">
@@ -180,7 +180,7 @@ the POST data again.</p>
 </div> <!-- id="main" -->
 
 <div id="about">
-	<p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
+        <p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
 </div> <!-- id="about" -->
 
 </div> <!-- id="container" -->

--- a/doc/us/license.html
+++ b/doc/us/license.html
@@ -3,9 +3,9 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<title>WSAPI</title>
+        <title>WSAPI</title>
     <link rel="stylesheet" href="doc.css" type="text/css"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 
 <body>
@@ -14,30 +14,30 @@
 
 <div id="product">
 
-	<div id="product_logo">
+        <div id="product_logo">
         <a href="http://wsapi.luaforge.net">
-		<img alt="WSAPI" src="wsapi.png"/>
-	    </a>
+                <img alt="WSAPI" src="wsapi.png"/>
+            </a>
     </div>
-	<div id="product_name"><big><strong>WSAPI</strong></big></div>
-	<div id="product_description">Lua Web Server API</div>
+        <div id="product_name"><big><strong>WSAPI</strong></big></div>
+        <div id="product_description">Lua Web Server API</div>
 </div> <!-- id="product" -->
 
 <div id="main">
-	
+
 <div id="navigation">
 <h1>WSAPI</h1>
-	<ul>
+        <ul>
 
-		<li><a href="index.html">Home</a></li>
+                <li><a href="index.html">Home</a></li>
 
-		<li><a href="manual.html">Manual</a></li>
+                <li><a href="manual.html">Manual</a></li>
 
-		<li><a href="libraries.html">Libraries</a></li>
+                <li><a href="libraries.html">Libraries</a></li>
 
-		<li><strong>License</strong></li>
+                <li><strong>License</strong></li>
 
-	</ul>
+        </ul>
 </div> <!-- id="navigation" -->
 
 <div id="content">
@@ -61,7 +61,7 @@ Its licenses are compatible with
 WSAPI is not in the public domain and the
 <a href="http://www.keplerproject.org">Kepler Project</a>
 keep its copyright.
-The legal details are below. 
+The legal details are below.
 </p>
 
 
@@ -83,7 +83,7 @@ The implementation is not derived from licensed software.</p>
 <hr/>
 
 
-<p>Copyright &copy; 2007-2010 Kepler Project.</p>
+<p>Copyright &copy; 2007-2014 Kepler Project.</p>
 
 
 
@@ -119,7 +119,7 @@ SOFTWARE.</p>
 </div> <!-- id="main" -->
 
 <div id="about">
-	<p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
+        <p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
 </div> <!-- id="about" -->
 
 </div> <!-- id="container" -->

--- a/doc/us/license.md
+++ b/doc/us/license.md
@@ -13,7 +13,7 @@ Its licenses are compatible with
 WSAPI is not in the public domain and the
 <a href="http://www.keplerproject.org">Kepler Project</a>
 keep its copyright.
-The legal details are below. 
+The legal details are below.
 </p>
 
 <p>The spirit of the license is that you are free to use
@@ -27,7 +27,7 @@ Andr&eacute; Carregal.
 The implementation is not derived from licensed software.</p>
 
 <hr/>
-<p>Copyright &copy; 2007-2013 Kepler Project.</p>
+<p>Copyright &copy; 2007-2014 Kepler Project.</p>
 
 <p>Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -3,9 +3,9 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-	<title>WSAPI</title>
+        <title>WSAPI</title>
     <link rel="stylesheet" href="doc.css" type="text/css"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 
 <body>
@@ -14,30 +14,30 @@
 
 <div id="product">
 
-	<div id="product_logo">
+        <div id="product_logo">
         <a href="http://wsapi.luaforge.net">
-		<img alt="WSAPI" src="wsapi.png"/>
-	    </a>
+                <img alt="WSAPI" src="wsapi.png"/>
+            </a>
     </div>
-	<div id="product_name"><big><strong>WSAPI</strong></big></div>
-	<div id="product_description">Lua Web Server API</div>
+        <div id="product_name"><big><strong>WSAPI</strong></big></div>
+        <div id="product_description">Lua Web Server API</div>
 </div> <!-- id="product" -->
 
 <div id="main">
-	
+
 <div id="navigation">
 <h1>WSAPI</h1>
-	<ul>
+        <ul>
 
-		<li><a href="index.html">Home</a></li>
+                <li><a href="index.html">Home</a></li>
 
-		<li><strong>Manual</strong></li>
+                <li><strong>Manual</strong></li>
 
-		<li><a href="libraries.html">Libraries</a></li>
+                <li><a href="libraries.html">Libraries</a></li>
 
-		<li><a href="license.html">License</a></li>
+                <li><a href="license.html">License</a></li>
 
-	</ul>
+        </ul>
 </div> <!-- id="navigation" -->
 
 <div id="content">
@@ -55,7 +55,7 @@ installed use the <code>wsapi-xavante</code> LuaRocks package.</p>
 local Rocks repository.</p>
 
 <p>There is an all-in-one installer script that installs Lua, LuaRocks, and <code>wsapi-xavante</code> in
-a single step. Download the <a href="http://github.com/downloads/keplerproject/wsapi/wsapi-install-1.3.0.tar.gz">tarball</a>,
+a single step. Download the <a href="http://www.keplerproject.org/files/wsapi-install-1.6.0.tar.gz">tarball</a>,
 unpack it, then run the provided <code>wsapi-install</code> script in its path. Run <code>wsapi-install --help</code> for
 installation options.</p>
 
@@ -105,9 +105,9 @@ provided with WSAPI respect this pattern.</p>
 <pre class="example">
 #!/usr/bin/env wsapi.cgi
 
-module(..., package.seeall)
+local _M = {}
 
-function run(wsapi_env)
+function _M.run(wsapi_env)
   local headers = { ["Content-type"] = "text/html" }
 
   local function hello_text()
@@ -120,6 +120,8 @@ function run(wsapi_env)
 
   return 200, headers, coroutine.wrap(hello_text)
 end
+
+return _M
 </pre>
 
 
@@ -167,9 +169,9 @@ script is very similar for both connectors. For CGI it can be this one (<em>hell
 <pre class="example">
 #!/usr/bin/env lua
 
-require "wsapi.cgi"
-require "hello"
-wsapi.cgi.run(hello.run)
+local cgi = require "wsapi.cgi"
+local hello = require "hello"
+cgi.run(hello.run)
 </pre>
 
 
@@ -179,9 +181,9 @@ wsapi.cgi.run(hello.run)
 <pre class="example">
 #!/usr/bin/env lua
 
-require "wsapi.fastcgi"
-require "hello"
-wsapi.fastcgi.run(hello.run)
+local fastcgi = require "wsapi.fastcgi"
+local hello = require "hello"
+fastcgi.run(hello.run)
 </pre>
 
 
@@ -304,7 +306,7 @@ end
 </div> <!-- id="main" -->
 
 <div id="about">
-	<p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
+        <p><a href="http://validator.w3.org/check?uri=referer">Valid XHTML 1.0!</a></p>
 </div> <!-- id="about" -->
 
 </div> <!-- id="container" -->

--- a/rockspec/wsapi-1.6.1-1.rockspec
+++ b/rockspec/wsapi-1.6.1-1.rockspec
@@ -1,0 +1,36 @@
+package = "WSAPI"
+
+version = "1.6.1-1"
+
+description = {
+  summary = "Lua Web Server API",
+  detailed = [[
+    WSAPI is an API that abstracts the web server from Lua web applications. This is the rock
+    that contains the base WSAPI libraries plus the CGI adapters.
+  ]],
+  license = "MIT/X11",
+  homepage = "http://www.keplerproject.org/wsapi"
+}
+
+dependencies = { "luafilesystem >= 1.6.2" }
+
+source = {
+  url = "http://www.keplerproject.org/files/wsapi-1.6.1.tar.gz"
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["wsapi"] = "src/wsapi.lua",
+    ["wsapi.common"] = "src/wsapi/common.lua",
+    ["wsapi.request"] = "src/wsapi/request.lua",
+    ["wsapi.response"] = "src/wsapi/response.lua",
+    ["wsapi.util"] = "src/wsapi/util.lua",
+    ["wsapi.cgi"] = "src/wsapi/cgi.lua",
+    ["wsapi.sapi"] = "src/wsapi/sapi.lua",
+    ["wsapi.ringer"] = "src/wsapi/ringer.lua",
+    ["wsapi.mock"] = "src/wsapi/mock.lua",
+  },
+  copy_directories = { "samples", "doc", "tests" },
+  install = { bin = { "src/launcher/wsapi.cgi" } }
+}

--- a/rockspec/wsapi-fcgi-1.6.1-1.rockspec
+++ b/rockspec/wsapi-fcgi-1.6.1-1.rockspec
@@ -1,0 +1,60 @@
+package = "WSAPI-FCGI"
+
+version = "1.6.1-1"
+
+description = {
+  summary = "Lua Web Server API FastCGI Adapter",
+  detailed = [[
+    WSAPI is an API that abstracts the web server from Lua web applications. This
+    is the rock that contains the FCGI module lfcgi.
+  ]],
+  license = "MIT/X11",
+  homepage = "http://www.keplerproject.org/wsapi"
+}
+
+dependencies = { "wsapi >= 1.6.1", "rings >= 1.3.0", "coxpcall >= 1.14" }
+
+external_dependencies = {
+  platforms = {
+    unix = {
+      FASTCGI = {
+        header = "fcgi_stdio.h"
+      }
+    }
+  }
+}
+
+source = {
+  url = "http://www.keplerproject.org/files/wsapi-1.6.1.tar.gz"
+}
+
+build = {
+  platforms = {
+    unix = {
+      type = "builtin",
+      modules = {
+        ["wsapi.fastcgi"] = "src/wsapi/fastcgi.lua",
+        lfcgi = {
+          sources = "src/fastcgi/lfcgi.c",
+          libraries = "fcgi",
+          incdirs = "$(FASTCGI_INCDIR)",
+          libdirs = "$(FASTCGI_LIBDIR)"
+        }
+      },
+      install = { bin = { "src/launcher/wsapi.fcgi" } }
+    },
+    windows = {
+      type = "builtin",
+      modules = {
+        ["wsapi.fastcgi"] = "src/wsapi/fastcgi.lua",
+        lfcgi = {
+          sources = "src/fastcgi/lfcgi.c",
+          libraries = { "libfcgi", "ws2_32" },
+          incdirs = "$(FASTCGI_INCDIR)",
+          libdirs = "$(FASTCGI_LIBDIR)"
+        }
+      },
+      install = { bin = { "src/launcher/wsapi.fcgi" } }
+    }
+  }
+}

--- a/rockspec/wsapi-xavante-1.6.1-1.rockspec
+++ b/rockspec/wsapi-xavante-1.6.1-1.rockspec
@@ -1,0 +1,27 @@
+package = "WSAPI-Xavante"
+
+version = "1.6.1-1"
+
+description = {
+  summary = "Lua Web Server API - Xavante Handler",
+  detailed = [[
+    WSAPI is an API that abstracts the web server from Lua web applications. This is the rock
+    that contains the Xavante adapter and launcher.
+  ]],
+  license = "MIT/X11",
+  homepage = "http://www.keplerproject.org/wsapi"
+}
+
+dependencies = { "wsapi >= 1.6.1", "rings >= 1.3.0", "coxpcall >= 1.14", "xavante >= 2.3.0" }
+
+source = {
+  url = "http://www.keplerproject.org/files/wsapi-1.6.1.tar.gz"
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["wsapi.xavante"] = "src/wsapi/xavante.lua"
+  },
+  install = { bin = { "src/launcher/wsapi" } }
+}

--- a/src/wsapi/ringer.lua
+++ b/src/wsapi/ringer.lua
@@ -23,9 +23,10 @@ local init = [==[
     _, package.cpath = remotedostring("return package.cpath")
   end
   local common = require"wsapi.common"
-  require"coxpcall"
-  pcall = copcall
-  xpcall = coxpcall
+  local coxpcall = require "coxpcall"
+  pcall = coxpcall.pcall
+  xpcall = coxpcall.xpcall
+  
   local wsapi_error = {
        write = function (self, err)
          remotedostring("env.error:write(...)", err)


### PR DESCRIPTION
Prepares the 1.6.1 release by updating the documentation
and adding new rockspecs. It also fixes a bug in ringer.lua
related to coxpcall usage.
