### PR TITLE
Prevent segmentation fault on Android

### DIFF
--- a/src/wsapi/ringer.lua
+++ b/src/wsapi/ringer.lua
@@ -93,7 +93,7 @@ local init = [==[
            remotedostring("local k, v = ...; table.insert(headers[k], v)", k, val)
          end
        else
-         remotedostring("local k, v = ...; headers[k] = v", k, v)
+         remotedostring("local k, v = ...; rawset(headers, k, v)", k, v)
        end
      end
      local s, v = res()


### PR DESCRIPTION
somehow the method used produces a segfault, very obscure bug..., using rawset() as a workaround.