### PR TITLE
fix: change to work with CGILua 6.x

### DIFF
--- a/src/wsapi/sapi.lua
+++ b/src/wsapi/sapi.lua
@@ -49,8 +49,8 @@ function _M.run(wsapi_env)
       end,
     },
   }
-  local cgilua = require "cgilua"
-  cgilua.main()
+  local cgilua = require "cgilua.main"
+  cgilua.main(wsapi_env, res)
   return res:finish()
 end
 


### PR DESCRIPTION
There have been some changes in CGILua 6.x, this PR adds the missing parameters to `cgilua.main()` call in SAPI.