### PR TITLE
Update URL to Ruby's Rack [ci skip]

### DIFF
--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -54,7 +54,7 @@ and output buffering. You can also write applications that act as filters that
 provide some kind of service to other applications, such as authentication,
 file uploads, request isolation, or multiplexing.</p>
 
-<p>WSAPI's main influence is Ruby's <a href="http://rack.rubyforge.org/">Rack</a> framework, but it was
+<p>WSAPI's main influence is Ruby's <a href="https://github.com/rack/rack">Rack</a> framework, but it was
 also influenced by Python's <a href="http://wsgi.org/wsgi">WSGI</a> (PEP 333). It's not a direct
 clone of either of them, though, and tries to follow standard Lua idioms.</p>
 

--- a/doc/us/index.md
+++ b/doc/us/index.md
@@ -9,7 +9,7 @@ and output buffering. You can also write applications that act as filters that
 provide some kind of service to other applications, such as authentication,
 file uploads, request isolation, or multiplexing.
 
-WSAPI's main influence is Ruby's [Rack](http://rack.rubyforge.org/) framework, but it was
+WSAPI's main influence is Ruby's [Rack](https://github.com/rack/rack) framework, but it was
 also influenced by Python's [WSGI](http://wsgi.org/wsgi) (PEP 333). It's not a direct
 clone of either of them, though, and tries to follow standard Lua idioms.
 


### PR DESCRIPTION
Many years ago, that URL stopped working.